### PR TITLE
Implemented GDPR compliant button to enforce accetpance of all apps. …

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ var orejimeConfig = {
 
     // You must provide a link to your privacy policy page
     privacyPolicy: "",
+    
+    // Optional. Replaces the existing "Accept" button with an "Accept all" option. To ensure
+    // GDPR compliancy.
+    gdprCompliant: false,
 
     // Optional. Applications configured below will be ON by default if default=true.
     // defaults to true

--- a/dist/index.html
+++ b/dist/index.html
@@ -44,6 +44,8 @@
             window.orejimeConfig = {
                 appElement: "#app",
                 privacyPolicy: "#privacyPolicy",
+                gdprCompliant: true,
+                default: false,
                 translations: {
                     en: {
                         consentModal: {
@@ -84,8 +86,7 @@
                     {
                         name: "disabled-by-default",
                         title: "Something disabled by default",
-                        purposes: ["ads"],
-                        default: false
+                        purposes: ["ads"]
                     },
                     {
                         name: "always-on",

--- a/src/components/consent-notice.js
+++ b/src/components/consent-notice.js
@@ -10,6 +10,7 @@ export default class ConsentNotice extends React.Component {
             isMandatory,
             t,
             ns,
+            onSaveRequestAcceptAll,
             onSaveRequest,
             onDeclineRequest,
             onConfigRequest
@@ -54,8 +55,19 @@ export default class ConsentNotice extends React.Component {
                 {manager.changed &&
                     <p className={ns('Notice-changes')}>{t(['consentNotice', 'changeDescription'])}</p>
                 }
-
                 <ul className={ns('Notice-actions')}>
+                {config.gdprCompliant &&
+                        <li className={ns('Notice-actionItem Notice-actionItem--save')}>
+                          <button
+                            className={ns('Button Button--save Notice-button Notice-saveButton')}
+                            type="button"
+                            onClick={onSaveRequestAcceptAll}
+                          >
+                              {t(['acceptAll'])}
+                           </button>
+                        </li>
+                }
+                {!config.gdprCompliant &&
                     <li className={ns('Notice-actionItem Notice-actionItem--save')}>
                          <button
                             className={ns('Button Button--save Notice-button Notice-saveButton')}
@@ -65,6 +77,7 @@ export default class ConsentNotice extends React.Component {
                             {t(['accept'])}
                         </button>
                     </li>
+                }
                     <li className={ns('Notice-actionItem Notice-actionItem--decline')}>
                          <button
                             className={ns('Button Button--decline Notice-button Notice-declineButton')}

--- a/src/components/main.js
+++ b/src/components/main.js
@@ -10,6 +10,7 @@ export default class Main extends React.Component {
         }
         this.showModal = this.showModal.bind(this)
         this.hideModal = this.hideModal.bind(this)
+        this.saveAndHideAcceptAll= this.saveAndHideAcceptAll.bind(this)
         this.saveAndHideAll = this.saveAndHideAll.bind(this)
         this.declineAndHideAll = this.declineAndHideAll.bind(this)
     }
@@ -50,6 +51,14 @@ export default class Main extends React.Component {
         this.setState({isModalVisible: this.isModalVisible(false)})
     }
 
+    saveAndHideAcceptAll(e) {
+        if (e !== undefined) {
+            e.preventDefault()
+        }
+        this.props.manager.saveAndApplyAllConsents()
+        this.setState({isModalVisible: this.isModalVisible(false)})
+    }
+
     saveAndHideAll(e) {
         if (e !== undefined) {
             e.preventDefault()
@@ -79,6 +88,7 @@ export default class Main extends React.Component {
                     config={config}
                     manager={manager}
                     onSaveRequest={this.saveAndHideAll}
+                    onSaveRequestAcceptAll={this.saveAndHideAcceptAll}
                     onDeclineRequest={this.declineAndHideAll}
                     onConfigRequest={this.showModal}
                 />

--- a/src/consent-manager.js
+++ b/src/consent-manager.js
@@ -63,6 +63,12 @@ export default class ConsentManager {
         return consents
     }
 
+    acceptAll(){
+        this.config.apps.map((app) => {
+            this.updateConsent(app, true)
+        })
+    }
+
     declineAll(){
         this.config.apps.map((app) => {
             this.updateConsent(app, false)
@@ -138,6 +144,12 @@ export default class ConsentManager {
             this.notify('consents', this.consents)
         }
         return this.consents
+    }
+
+    saveAndApplyAllConsents(){
+        this.acceptAll()
+        this.saveConsents()
+        this.applyConsents()
     }
 
     saveAndApplyConsents(){


### PR DESCRIPTION
…Orejime config object updated to enable/disable this feature.

Currently, Orejime provides a non-useful "accept" button in a GDPR-compliant world. The initial pop-up has an "Accept" button, but this will only accept categories that are set to "Enabled" by default (which is not allowed by GDPR). 

So this PR would help fix that by presenting an "Accept all" button (similar to the button on the modal interface behind "Learn More"). It is a configurable feature since it exposes a bool option in the orejime config object so the default behaviour can still remain.



