### PR TITLE
feat(#78): allow cookieExpiresAfterDays as a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,12 @@ var orejimeConfig = {
     // defaults to "orejime".
     cookieName: "orejime",
 
-    // Optional. You can set a custom expiration time for the Orejime cookie, in days.
+    // Optional. You can set a custom expiration time for the Orejime cookie, in days,
+    // by using an integer or a function returning an integer.
+    // The function has the following signature: `function cookieExpiresAfterDays (consents, config): integer`
+    //  - consents is an object of apps name defined in `config.apps[].name` with their consent value as a boolean (same as the cookie value).
+    //  - config is your defined configuration (this object).
+    // You can find a snippet function here: https://github.com/empreinte-digitale/orejime/pull/79#issue-1100817288
     // defaults to 365.
     cookieExpiresAfterDays: 365,
 

--- a/src/consent-manager.js
+++ b/src/consent-manager.js
@@ -127,11 +127,24 @@ export default class ConsentManager {
 	saveConsents() {
 		if (this.consents === null) deleteCookie(this.cookieName);
 		const value = this.config.stringifyCookie(this.consents);
+		const configCookieExpiresAfterDays = this.config.cookieExpiresAfterDays;
+
+		let cookieExpiresAfterDays =
+			typeof configCookieExpiresAfterDays === 'function'
+				? configCookieExpiresAfterDays(this.consents, this.config)
+				: configCookieExpiresAfterDays;
+
+		if (
+			cookieExpiresAfterDays === null ||
+			cookieExpiresAfterDays === undefined
+		) {
+			cookieExpiresAfterDays = 120;
+		}
 
 		setCookie(
 			this.cookieName,
 			value,
-			this.config.cookieExpiresAfterDays || 120,
+			cookieExpiresAfterDays,
 			this.config.cookieDomain
 		);
 

--- a/src/consent-manager.js
+++ b/src/consent-manager.js
@@ -129,17 +129,10 @@ export default class ConsentManager {
 		const value = this.config.stringifyCookie(this.consents);
 		const configCookieExpiresAfterDays = this.config.cookieExpiresAfterDays;
 
-		let cookieExpiresAfterDays =
+		const cookieExpiresAfterDays =
 			typeof configCookieExpiresAfterDays === 'function'
 				? configCookieExpiresAfterDays(this.consents, this.config)
-				: configCookieExpiresAfterDays;
-
-		if (
-			cookieExpiresAfterDays === null ||
-			cookieExpiresAfterDays === undefined
-		) {
-			cookieExpiresAfterDays = 120;
-		}
+				: configCookieExpiresAfterDays || 120;
 
 		setCookie(
 			this.cookieName,


### PR DESCRIPTION
This allow to conditionally define cookie duration based on user consent.

Here a snippet function to control cookie duration using a function:

```js
// orejime.config.js
const config = {
  /* ... */
  cookieExpiresAfterDays(consents, config) {
		if (consents) {
			// ignore required apps (true is enforced)
			const consentableApps = config.apps
				.filter((app) => app.required !== true)
				.map((app) => app.name);
			// get selected user apps
			const userConsents = Object.values(
				Object.fromEntries(
					Object.entries(consents).filter(([name]) =>
						consentableApps.includes(name)
					)
				)
			);

			// cookie will expire after 90 days for users who accepted all apps
			if (userConsents.every((value) => value === true)) {
				return 90;
			}

			// otherwise (all apps refused or not all accepted) cookie will expire after 30 days
			return 30;
		}
	},
  /* ... */
}
```

Resolves: #78 