### PR TITLE
Handling consent exemption

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,11 +231,14 @@ var orejimeConfig = {
 
             // Optional. If "required" is set to true, Orejime will not allow this app to
             // be disabled by the user.
+            // See "Special cases" below for more information.
             // default to false
             required: false,
 
-            // Optional. If "optOut" is set to true, Orejime will load this app even before
-            // the user gave explicit consent.We recommend always leaving this "false".
+            // Optional. If "optOut" is set to true, Orejime will load this app
+            // even before the user gave explicit consent.
+            // We recommend always leaving this "false".
+            // See "Special cases" below for more information.
             // defaults to false
             optOut: false,
 
@@ -290,6 +293,17 @@ var orejimeConfig = {
 ```
 
 </details>
+
+#### Special cases
+
+##### Exemption
+
+If every app is either `required` or `optOut`, Orejime will not show at startup
+(but it will still be possible to open it programmatically).
+However, you should consider this use case carefully, and ensure that :
+* `required` trackers are truly required for your app to function properly
+* `optOut` trackers are exempt from consent, (i.e.
+[as defined by the CNIL](https://www.cnil.fr/fr/cookies-solutions-pour-les-outils-de-mesure-daudience))
 
 ### Initialization
 

--- a/src/components/main.js
+++ b/src/components/main.js
@@ -34,6 +34,9 @@ export default class Main extends React.Component {
 		if (manager.confirmed && !manager.changed) {
 			return false;
 		}
+		if (manager.canBypassConsent()) {
+			return false;
+		}
 		return true;
 	}
 

--- a/src/consent-manager.js
+++ b/src/consent-manager.js
@@ -55,6 +55,14 @@ export default class ConsentManager {
 		return consents;
 	}
 
+	// If every app is either required or optOut, or both,
+	// there is no need to ask for user consent.
+	canBypassConsent() {
+		return this.config.apps.every(
+			({optOut = false, required = false}) => optOut || required
+		);
+	}
+
 	declineAll() {
 		this.config.apps.map((app) => {
 			this.updateConsent(app, false);


### PR DESCRIPTION
If every app is either `required` or `optOut`, Orejime will not show at startup.