### PR TITLE
Fixed security attributes on script tags

### DIFF
--- a/src/consent-manager.js
+++ b/src/consent-manager.js
@@ -202,6 +202,8 @@ export default class ConsentManager {
 				newElement.name = element.name;
 				newElement.defer = element.defer;
 				newElement.async = element.async;
+				newElement.crossOrigin = element.crossOrigin;
+				newElement.integrity = element.integrity;
 
 				if (consent) {
 					newElement.type = type;


### PR DESCRIPTION
When activating a script, we're transfering the `crossorigin` and `integrity` attributes. 
This is a quick fix that will be better handled in v3 by transfering each and every attribute. 
Fixes #106