### PR TITLE
Validating URLs used in tag attributes

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -211,6 +211,12 @@
 		<script src="orejime.js"></script>
 		<script src="example-assets/setCookie.js"></script>
 
+		<iframe
+			type="opt-in"
+			data-src="javascript:alert('Error: This should never be evaluated.')"
+			data-name="always-on"
+		></iframe>
+
 		<script
 			type="opt-in"
 			data-src="example-assets/external-tracker.js"

--- a/src/consent-manager.js
+++ b/src/consent-manager.js
@@ -1,4 +1,5 @@
 import {getCookie, getCookies, setCookie, deleteCookie} from './utils/cookies';
+import {isSafeUrl} from './utils/validation';
 
 export default class ConsentManager {
 	constructor(config) {
@@ -217,7 +218,11 @@ export default class ConsentManager {
 				if (consent) {
 					for (var attr of attrs) {
 						const attrValue = dataset[attr];
-						if (attrValue === undefined) continue;
+
+						if (attrValue === undefined || !isSafeUrl(attrValue)) {
+							continue;
+						}
+
 						if (dataset['original' + attr] === undefined)
 							dataset['original' + attr] = element[attr];
 						element[attr] = attrValue;

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -1,0 +1,10 @@
+// Checks that the given URL is a regular HTTP resource, and
+// not malicious code (i.e. `javascript:...`).
+export const isSafeUrl = (url) => {
+	try {
+		const parsed = new URL(url, window.location);
+		return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+	} catch (e) {
+		return false;
+	}
+};


### PR DESCRIPTION
One could have injected arbitrary code by using the `javascript:` protocol within `href` or `src` attributes.
We're now enforcing that the URL uses HTTP.
Using `URL` instead of checking for a protocol in the string allows proper handling of relative URLs.