### PR TITLE
Fixed cookie deletion

### DIFF
--- a/e2e/orejime.spec.ts
+++ b/e2e/orejime.spec.ts
@@ -255,6 +255,14 @@ test.describe('Orejime', () => {
 		const position2 = await orejimePage.banner.boundingBox();
 		await expect(position2).toEqual(initalPosition);
 	});
+
+	test('should clear consents', async () => {
+		await orejimePage.expectUndefinedConsents();
+		await orejimePage.acceptAllFromManager();
+		await orejimePage.expectAnyConsents();
+		await orejimePage.clearConsents();
+		await orejimePage.expectUndefinedConsents();
+	});
 });
 
 test.describe('Orejime with forced banner', () => {

--- a/src/core/utils/cookies.ts
+++ b/src/core/utils/cookies.ts
@@ -1,4 +1,5 @@
 import Cookie from 'js-cookie';
+import {listSubdomains} from './urls';
 
 export type CookieSameSite = 'strict' | 'lax' | 'none';
 
@@ -24,24 +25,15 @@ export const setCookie = (
 	});
 };
 
-export const deleteCookie = (name: string, path?: string, domain?: string) => {
-	if (domain) {
+export const deleteCookie = (name: string, path = '/', domain?: string) => {
+	// If no domain is specified, we try deleting the cookie
+	// on the current domain or any of its subdomains.
+	const domains = domain ? [domain] : listSubdomains(location.hostname);
+
+	domains.forEach((domain) => {
 		Cookie.remove(name, {
 			path,
 			domain
 		});
-
-		return;
-	}
-
-	// if domain is not defined, try to delete cookie on multiple default domains
-	Cookie.remove(name, {
-		path,
-		domain: location.hostname
-	});
-
-	Cookie.remove(name, {
-		path,
-		domain: location.hostname.split('.').slice(-2).join('.')
 	});
 };

--- a/src/core/utils/urls.test.ts
+++ b/src/core/utils/urls.test.ts
@@ -1,0 +1,19 @@
+import {listSubdomains} from './urls';
+
+test('listSubdomains', () => {
+	expect(listSubdomains('localhost')).toEqual(
+		expect.arrayContaining(['localhost'])
+	);
+
+	expect(listSubdomains('foo.com')).toEqual(
+		expect.arrayContaining(['foo.com'])
+	);
+
+	expect(listSubdomains('foo.bar.com')).toEqual(
+		expect.arrayContaining(['bar.com', 'foo.bar.com'])
+	);
+
+	expect(listSubdomains('foo.bar.baz.com')).toEqual(
+		expect.arrayContaining(['baz.com', 'bar.baz.com', 'foo.bar.baz.com'])
+	);
+});

--- a/src/core/utils/urls.ts
+++ b/src/core/utils/urls.ts
@@ -1,0 +1,12 @@
+export const listSubdomains = (hostname: string) => {
+	const parts = hostname.split('.');
+	const primary = parts.slice(-2);
+	const subs = parts.slice(0, -2);
+	const all = [primary];
+
+	for (let i = 0; i < subs.length; i++) {
+		all.push(subs.slice(i).concat(primary));
+	}
+
+	return all.map((parts) => parts.join('.'));
+};


### PR DESCRIPTION
In some cases, cookies weren't properly deleted.
The path is now set to '/' by default, and deletion is attempted on any possible subdomain instead of only the two extremes.