### PR TITLE
Fixed collision resolution

### DIFF
--- a/e2e/orejime.spec.ts
+++ b/e2e/orejime.spec.ts
@@ -44,6 +44,13 @@ test.describe('Orejime', () => {
 				</template>
 
 				<button
+					id="obscuring"
+					style="position: absolute; bottom: 6rem; right: 3rem; z-index: 9999;"
+				>
+					Obscuring
+				</button>
+
+				<button
 					id="obscured"
 					style="position: absolute; bottom: 3rem; right: 3rem;"
 				>
@@ -254,6 +261,14 @@ test.describe('Orejime', () => {
 
 		const position2 = await orejimePage.banner.boundingBox();
 		await expect(position2).toEqual(initalPosition);
+
+		// When a button above the banner takes focus, the
+		// banner shouldn't be displaced either.
+		const obscuring = orejimePage.locator('#obscuring');
+		await obscuring.focus();
+
+		const position3 = await orejimePage.banner.boundingBox();
+		await expect(position3).toEqual(initalPosition);
 	});
 
 	test('should clear consents', async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "jest": "^28.1.3",
         "jest-environment-jsdom": "^28.1.0",
         "js-cookie": "^3.0.1",
-        "micromodal": "^0.4.10",
+        "micromodal": "^0.6.1",
         "postcss-loader": "^8.1.1",
         "postcss-preset-env": "^10.1.5",
         "preact": "^10.23.2",
@@ -11894,9 +11894,9 @@
       }
     },
     "node_modules/micromodal": {
-      "version": "0.4.10",
-      "resolved": "https://registry.npmjs.org/micromodal/-/micromodal-0.4.10.tgz",
-      "integrity": "sha512-BUrEnzMPFBwK8nOE4xUDYHLrlGlLULQVjpja99tpJQPSUEWgw3kTLp1n1qv0HmKU29AiHE7Y7sMLiRziDK4ghQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/micromodal/-/micromodal-0.6.1.tgz",
+      "integrity": "sha512-rw1fOptxQe3XGDm9xil9hBC2ylPb1kKZyYv4FlK54R/7L+KG+D8SQxPL5L8OlEXAhBDHckeoULYxWSYU9rg/RA==",
       "dev": true,
       "license": "ISC",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "jest": "^28.1.3",
     "jest-environment-jsdom": "^28.1.0",
     "js-cookie": "^3.0.1",
-    "micromodal": "^0.4.10",
+    "micromodal": "^0.6.1",
     "postcss-loader": "^8.1.1",
     "postcss-preset-env": "^10.1.5",
     "preact": "^10.23.2",

--- a/src/ui/utils/dom.ts
+++ b/src/ui/utils/dom.ts
@@ -89,12 +89,36 @@ const getPaddedBoundingBox = (element: DOMRect, padding: number) => ({
 	left: element.left + padding
 });
 
+// A naive way to estimate the z-index of an element.
+// This does not take each and every stacking context rules
+// into account but merely adds up every z-indexes set on
+// the element's ancestors.
+const getZIndex = (element: HTMLElement): number => {
+	const base =
+		element.offsetParent instanceof HTMLElement
+			? getZIndex(element.offsetParent)
+			: 0;
+
+	const style = window.getComputedStyle(element);
+	const z = parseInt(style.zIndex, 10) || 0;
+
+	return base + z;
+};
+
 // Resolves a visual collision between two elements, either
 // by scrolling the page or moving one of them.
 // We're only resolving collisions on the vertical axis, as
 // it is the main direction of web pages.
 export const resolveCollision = (fixed: HTMLElement, mobile: HTMLElement) => {
 	if (mobile.contains(fixed)) {
+		translateElementY(mobile, 0);
+		return;
+	}
+
+	// If the fixed element is meant to obscure the mobile
+	// one (i.e. positionned absolutely above), there is no
+	// need to move anything.
+	if (getZIndex(fixed) > getZIndex(mobile)) {
 		translateElementY(mobile, 0);
 		return;
 	}


### PR DESCRIPTION
If a focused element is positionned above the movable one, we're not moving the mobile one anymore.
This avoids weird flickerings happenning while focus was set on a full page element, thus pushing the mobile element outside of the page and inside again.

Fixes #136