### PR TITLE
Npm trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,29 @@
+name: Publication
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      DIST_TAG: |-
+        ${{ case(
+          contains(github.ref_name, 'alpha'), 'alpha',
+          startsWith(github.ref_name, 'v2'), 'previous',
+          'latest'
+        ) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - run: npm ci
+      - run: npx playwright install --with-deps
+      - run: npm publish --tag $DIST_TAG

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 registry=https://registry.npmjs.org
+provenance=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "orejime",
-  "version": "3.1.1",
+  "version": "3.1.2-alpha.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "orejime",
-      "version": "3.1.1",
+      "version": "3.1.2-alpha.0",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@playwright/test": "^1.48.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orejime",
-  "version": "3.1.1",
+  "version": "3.1.2-alpha.0",
   "description": "A lightweight and accessible consent manager",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Publishing is now done via a GitHub Action using npm trusted publishing, as to automate and secure the process.